### PR TITLE
Better scrolling and style consistency

### DIFF
--- a/js/comment-collapser.js
+++ b/js/comment-collapser.js
@@ -203,7 +203,7 @@ function smoothScroll(destination) {
     window.requestAnimationFrame(function step () {
         let elapsed = Date.now() - startTime;
 
-        window.scroll(0, getComputedPosition(startScroll, destination, elapsed));
+        window.scroll(window.scrollX, getComputedPosition(startScroll, destination, elapsed));
 
         if (elapsed <= settings.animationTimeInMs) {
             window.requestAnimationFrame(step);


### PR DESCRIPTION
Only need to check if the top of the comment is above the viewport, since it won't be clickable if it's below.

`window.scroll` can do smooth scrolling in newer browsers. (only Firefox right now, but Chrome supports it behind a chrome://flags option). 