### PR TITLE
Make collapsing more accurate/efficient and remove custom expander

### DIFF
--- a/css/comment-collapser.css
+++ b/css/comment-collapser.css
@@ -2,14 +2,7 @@
     position: static !important;
 }
 
-.expander {
-    font-style: normal !important;
-    margin-right: 3px;
-    padding: 1px;
-}
-
 body .comment .child {
-    margin-top: 10px;
     margin-left: 15px;
 }
 
@@ -17,11 +10,14 @@ body .comment .child {
     position: relative;
 }
 
-.comment.noncollapsed.deleted .midcol {
+.comment.noncollapsed.deleted > .midcol {
     visibility: initial;
 }
+.comment.collapsed.deleted > .midcol {
+    visibility: hidden;
+}
 
-.comment.noncollapsed.deleted .arrow {
+.comment.noncollapsed.deleted > .midcol > .arrow {
     visibility: hidden;
 }
 

--- a/js/comment-collapser.js
+++ b/js/comment-collapser.js
@@ -215,7 +215,7 @@ let observer = new MutationObserver(function (mutations) {
 
         Array.from(mutation.addedNodes).forEach(function (node) {
             // Only continue if node is an element
-            if (node.nodeType !== 1 || !node.classList.contains('comment')) return;
+            if (node.nodeType !== Node.ELEMENT_NODE || !node.classList.contains('comment')) return;
 
             if (!once) {
                 once = true;

--- a/js/comment-collapser.js
+++ b/js/comment-collapser.js
@@ -11,8 +11,8 @@ function injectCSS() {
 
     // Find a comment to base sizes on
     let testComment = document.querySelector(`
-            .commentarea > .sitetable > .comment:not(.deleted),
-            .commentarea > .sitetable > #listings > .comment:not(.deleted)`);
+            .commentarea > .sitetable > .comment:not(.deleted):not(.collapsed),
+            .commentarea > .sitetable > #listings > .comment:not(.deleted):not(.collapsed)`);
 
     let midcol = testComment.querySelector(".midcol");
 


### PR DESCRIPTION
Removes a lot of unnecessary code.

* Triggers reddit's comment toggle instead of managing custom expanders and applying a bunch of arbitrary CSS rules.
* Height transition on main comment element instead of child tree. Allows for transitions to exact collapsed height without the small jump at the end.
* Small consistency or cleanup changes.